### PR TITLE
Rounding fix for Daily tally by protection area graph.

### DIFF
--- a/application.py
+++ b/application.py
@@ -191,7 +191,12 @@ def update_tally_zone(area, day_range):
 
     # Spatial clip
     if area == "ALL":
-        de = sliced.groupby(["FireSeason", "doy", "date_stacked"]).sum().reset_index()
+        de = (
+            sliced.groupby(["FireSeason", "doy", "date_stacked"])
+            .sum()
+            .reset_index()
+            .round(2)
+        )
     else:
         de = sliced.loc[(sliced["ProtectionUnit"] == area)]
 


### PR DESCRIPTION
This resolves issue #24 which showed undesired additional decimal places for the decimal value in the Statewide view of the Daily tally for protection area graph. This was due to the way the resulting decimal was created and simply need to be rounded again after the aggregation of the values around the state on a given day of the year.

To review:
* Ensure that there is only a single decimal place for the **Daily tally for protection area** graph for the default Statewide view