### PR TITLE
Remove Statewide total from Protection Area. Set Chugach as default displayed.

### DIFF
--- a/application.py
+++ b/application.py
@@ -190,10 +190,7 @@ def update_tally_zone(area, day_range):
     ]
 
     # Spatial clip
-    if area == "ALL":
-        de = sliced.groupby(["FireSeason", "doy", "date_stacked"]).sum().reset_index()
-    else:
-        de = sliced.loc[(sliced["ProtectionUnit"] == area)]
+    de = sliced.loc[(sliced["ProtectionUnit"] == area)]
 
     data_traces = []
     grouped = de.groupby("FireSeason")

--- a/gui.py
+++ b/gui.py
@@ -180,7 +180,7 @@ zone_dropdown = dcc.Dropdown(
     id="area",
     className="dropdown-selector",
     options=[{"label": luts.zones[key], "value": key} for key in luts.zones],
-    value="ALL",
+    value="CGF",
 )
 zone_dropdown_field = html.Div(
     className="field",

--- a/luts.py
+++ b/luts.py
@@ -42,19 +42,18 @@ years_lines_styles = {
 }
 
 zones = {
-    "ALL": "Statewide",
-    "MID": "Military Zone",
+    "CGF": "Chugach National Forest",
+    "CRS": "Copper River Area",
     "DAS": "Delta Area",
     "FAS": "Fairbanks Area",
-    "MSS": "Mat-Su Area",
-    "CRS": "Copper River Area",
-    "UYD": "Upper Yukon Zone",
-    "KKS": "Kenai/Kodiak Area",
-    "SWS": "Southwest Area",
-    "CGF": "Chugach National Forest",
     "GAD": "Galena Zone",
-    "TAS": "Tok Area",
     "HNS": "Haines Area",
+    "KKS": "Kenai/Kodiak Area",
+    "MID": "Military Zone",
+    "MSS": "Mat-Su Area",
+    "SWS": "Southwest Area",
     "TAD": "Tanana Zone",
+    "TAS": "Tok Area",
     "TNF": "Tongass National Forest",
+    "UYD": "Upper Yukon Zone",
 }


### PR DESCRIPTION
This PR removes the Statewide total from the Protection area chart and sets the default display to be Chugach.

It also removes the code to sum the acreage for the "ALL" Statewide total for that chart.

To review:

- Ensure that the Statewide Protection Chart is no longer available.
- Chugach is the default on original page load