### PR TITLE
Update for 2022 and fix empty statewide daily tally plot

### DIFF
--- a/data.py
+++ b/data.py
@@ -68,7 +68,7 @@ def collapse_year(date):
 
     try:
         d = datetime.strptime(str(date), "%Y%m%d")
-        d = d.replace(year=2021)
+        d = d.replace(year=2022)
     except ValueError:
         # Invalid date, return a null to be dropped
         logging.error("Invalid date found, %s", date)

--- a/luts.py
+++ b/luts.py
@@ -20,7 +20,7 @@ default_date_range = [get_doy(4, 1), get_doy(9, 16)]
 
 default_style = {"color": "rgba(0, 0, 0, 0.25)", "width": 1}
 
-important_years = [2004, 2005, 2009, 2010, 2013, 2015, 2019, 2021]
+important_years = [2004, 2005, 2009, 2010, 2013, 2015, 2019, 2022]
 years_lines_styles = {
     "2004": {"color": "rgba(100, 143, 255, 1)", "width": "2"},
     "2005": {"color": "rgba(120, 94, 240, 1)", "width": "2"},
@@ -39,7 +39,8 @@ years_lines_styles = {
     "2018": default_style,
     "2019": {"color": "rgba(10, 255, 128, 1)", "width": "2"},
     "2020": default_style,
-    "2021": {"color": "rgba(10, 25, 0, .85)", "width": "4"},
+    "2021": default_style,
+    "2022": {"color": "rgba(10, 25, 0, .85)", "width": "4"},
 }
 
 zones = {


### PR DESCRIPTION
Closes #35.

To test:
- The statewide daily tally plot near the top of the page should be populated with data
- 2022 should now show as the current year (the thick black line)