### PR TITLE
Unify chart hovertext values for all charts

### DIFF
--- a/application.py
+++ b/application.py
@@ -172,7 +172,8 @@ def update_tally(day_range):
         + get_title_date_span(day_range),
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
-        hovermode="x unified"
+        hovermode="x unified",
+        hoverdistance=1,
     )
     return {"data": data_traces, "layout": graph_layout}
 
@@ -239,6 +240,7 @@ def update_tally_zone(area, day_range):
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
         hovermode="x unified",
+        hoverdistance=1,
     )
     return {"data": data_traces, "layout": graph_layout}
 
@@ -284,7 +286,8 @@ def update_year_zone(year, day_range):
         + get_title_date_span(day_range),
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
-        hovermode="x unified"
+        hovermode="x unified",
+        hoverdistance=1,
     )
     return {"data": data_traces, "layout": graph_layout}
 

--- a/application.py
+++ b/application.py
@@ -172,6 +172,7 @@ def update_tally(day_range):
         + get_title_date_span(day_range),
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
+        hovermode="x unified"
     )
     return {"data": data_traces, "layout": graph_layout}
 
@@ -237,6 +238,7 @@ def update_tally_zone(area, day_range):
         + get_title_date_span(day_range),
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
+        hovermode="x unified",
     )
     return {"data": data_traces, "layout": graph_layout}
 
@@ -282,6 +284,7 @@ def update_year_zone(year, day_range):
         + get_title_date_span(day_range),
         xaxis=xaxis_conf,
         yaxis=yaxis_conf,
+        hovermode="x unified"
     )
     return {"data": data_traces, "layout": graph_layout}
 


### PR DESCRIPTION
Closes #39.

To test, load the app from this branch and make sure the hoverbox values are unified in all three charts.