### PR TITLE
Removes Upper Yukon / Tanana from available options for tally.

### DIFF
--- a/luts.py
+++ b/luts.py
@@ -57,6 +57,5 @@ zones = {
     "TAD": "Tanana Zone",
     "TAS": "Tok Area",
     "TNF": "Tongass National Forest",
-    "UYD": "Upper Yukon Zone",
-    "UYT": "Upper Yukon / Tanana",
+    "UYD": "Upper Yukon Zone"
 }


### PR DESCRIPTION
This PR removes the Upper Yukon / Tanana from the available dropdown options for the daily tally by protection area and the daily tally by year at the bottom of the page. 

Resolves #41 