### PR TITLE
Round acres burned chart values to whole numbers

### DIFF
--- a/application.py
+++ b/application.py
@@ -136,7 +136,7 @@ def update_tally(day_range):
             [
                 {
                     "x": group.date_stacked,
-                    "y": group.TotalAcres,
+                    "y": round(group.TotalAcres),
                     "mode": "lines",
                     "name": str(name),
                     "line": {
@@ -201,7 +201,7 @@ def update_tally_zone(area, day_range):
             [
                 {
                     "x": group.date_stacked,
-                    "y": group.TotalAcres,
+                    "y": round(group.TotalAcres),
                     "mode": "lines",
                     "name": name,
                     "line": {
@@ -266,7 +266,7 @@ def update_year_zone(year, day_range):
             [
                 {
                     "x": group.date_stacked,
-                    "y": group.TotalAcres,
+                    "y": round(group.TotalAcres),
                     "mode": "lines",
                     "name": luts.zones[name],
                     "line": {"shape": get_line_mode(day_range), "width": 2},


### PR DESCRIPTION
Closes #44.

To test, try hovering over each of the three charts and make sure all acres burned numbers are whole numbers (no decimal places).