### PR TITLE
Add 2024 and set it as the current year

### DIFF
--- a/data.py
+++ b/data.py
@@ -69,7 +69,7 @@ def collapse_year(date):
 
     try:
         d = datetime.strptime(str(date), "%Y%m%d")
-        d = d.replace(year=2023)
+        d = d.replace(year=2024)
     except ValueError:
         # Invalid date, return a null to be dropped
         logging.error("Invalid date found, %s", date)

--- a/luts.py
+++ b/luts.py
@@ -20,7 +20,7 @@ default_date_range = [get_doy(4, 1), get_doy(9, 16)]
 
 default_style = {"color": "rgba(0, 0, 0, 0.25)", "width": 1}
 
-important_years = [2004, 2005, 2009, 2010, 2013, 2015, 2019, 2022, 2023]
+important_years = [2004, 2005, 2009, 2010, 2013, 2015, 2019, 2022, 2024]
 years_lines_styles = {
     "2004": {"color": "rgba(100, 143, 255, 1)", "width": "2"},
     "2005": {"color": "rgba(120, 94, 240, 1)", "width": "2"},
@@ -41,7 +41,8 @@ years_lines_styles = {
     "2020": default_style,
     "2021": default_style,
     "2022": {"color": "rgba(1, 98, 1, 1)", "width": "2"},
-    "2023": {"color": "rgba(10, 25, 0, .85)", "width": "4"},
+    "2023": default_style,
+    "2024": {"color": "rgba(10, 25, 0, .85)", "width": "4"},
 }
 
 zones = {


### PR DESCRIPTION
This PR adds the year 2024 and styles it to be the current year. This also fixes the app, which will not run without this change.

To test, run the app and make sure you can see the beginnings of 2024 on the Statewide Daily Tally chart, styled with a thick black line to indicate that 2024 is the current year.