### PR TITLE
Prevent parse error due to goofed parsing of column type

### DIFF
--- a/data.py
+++ b/data.py
@@ -124,7 +124,10 @@ def fetch_api_data():
         )
         tally = preprocess_data(tally_raw)
 
-        tally_zone_raw = pd.read_csv(TALLY_DATA_ZONES_URL, parse_dates=True)
+        tally_zone_raw = pd.read_csv(
+            TALLY_DATA_ZONES_URL,
+            dtype={"FireSeason": "Int64", "SitReportDate": "Int64"},
+        )
         tally_zone_raw = tally_zone_raw.drop(
             columns=[
                 "ID",


### PR DESCRIPTION
In current versions of the Tally Zones CSV file, something was causing the Pandas CSV parser to see mixed types and interpret two key columns as floats.  Manually specifying the column type fixes the issue.

Testing it: checkout `main` and run the app; note there are a ton of exceptions thrown in the date handling code, and the charts for the zones don't work.  Switch to this branch and things should work OK.